### PR TITLE
Bump to PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=8.0"
     },
     "require-dev": {
         "illuminate/database": ">=5.4",
         "mockery/mockery" : "0.9.*|^1.0",
-        "phpunit/phpunit" : ">=7.0"
+        "phpunit/phpunit" : "^9.3|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/EloquentSuite.php
+++ b/src/EloquentSuite.php
@@ -18,7 +18,7 @@ trait EloquentSuite
 {
     use MocksMixins;
 
-    protected static $eloquent_relations = [
+    protected static array $eloquent_relations = [
         'hasOne' => Relations\HasOne::class,
         'hasMany' => Relations\HasMany::class,
         'morphTo' => Relations\MorphTo::class,
@@ -133,10 +133,11 @@ trait EloquentSuite
      *
      * @param  string $relation
      * @param  \Illuminate\Database\Eloquent\Relations\Relation $actual
-     * @param  string $message
+     * @param string $message
+     *
      * @return void
      */
-    public static function assertRelation(string $relation, Relations\Relation $actual, $message = '')
+    public static function assertRelation(string $relation, Relations\Relation $actual, string $message = ''): void
     {
         if (array_key_exists($relation, self::$eloquent_relations)) {
             $relation = self::$eloquent_relations[$relation];
@@ -150,9 +151,9 @@ trait EloquentSuite
             $relation,
             $actual,
             $message ?: 'Possible reasons:' .
-                        ' relation not defined on the model,' .
-                        ' unexpected query methods chained on relation object,' .
-                        ' missing return statement.'
+                ' relation not defined on the model,' .
+                ' unexpected query methods chained on relation object,' .
+                ' missing return statement.'
         );
     }
 


### PR DESCRIPTION
The updates are necessary to ensure compatibility with the latest versions of PHP and Laravel.

- [x]  Updated packages are compatible with PHP 8.x, Laravel 9.x and 10.x
- [x]  Updated packages do not introduce any regressions